### PR TITLE
fix/IPS_Get_Configuration

### DIFF
--- a/ModuleStubs.php
+++ b/ModuleStubs.php
@@ -55,7 +55,6 @@ class IPSModule
             $result[$name] = $property['Current'];
         }
 
-        //return $result;
         return json_encode($result);
     }
 

--- a/ModuleStubs.php
+++ b/ModuleStubs.php
@@ -55,7 +55,8 @@ class IPSModule
             $result[$name] = $property['Current'];
         }
 
-        return $result;
+        //return $result;
+        return json_encode($result);
     }
 
     public function SetConfiguration($Configuration)


### PR DESCRIPTION
Official IPS Code returns IPS_GetConfiguration as json_encoded string and docu says also.
But Test-Stubs returned as array. Changed return of IPS_GetConfiguration to json_encoded string.