### PR TITLE
Check hinzugefügt, wenn die Endzeit 0 ist

### DIFF
--- a/CoreStubs/ArchiveControl/module.php
+++ b/CoreStubs/ArchiveControl/module.php
@@ -68,7 +68,7 @@ class ArchiveControl extends IPSModule
         $return = [];
         foreach (array_reverse($aggregatedArchiveData) as $data) {
             if (count($return) < $Limit) {
-                if (($data['TimeStamp'] >= $StartTime) && (($data['TimeStamp'] + $data['Duration'] - 1) <= $EndTime)) {
+                if (($data['TimeStamp'] >= $StartTime) && ($EndTime == 0 || (($data['TimeStamp'] + $data['Duration'] - 1) <= $EndTime))) {
                     $return[] = $data;
                 }
             } else {


### PR DESCRIPTION
Wenn in GetAggregatedValues(), die Endzeit 0 übergeben wurde, wurde die Bedingung nicht erfüllt und somit ein leeres Array zurückgegeben