### PR TITLE
Hinzufügen von fehlender Instanz Id

### DIFF
--- a/ModuleStrictStubs.php
+++ b/ModuleStrictStubs.php
@@ -18,10 +18,12 @@ class IPSModuleStrict
 {
     private IPSModulePublic $module;
     private array $protectedMethods;
+    protected $InstanceID;
 
     public function __construct(int $InstanceID)
     {
         $this->module = new IPSModulePublic($InstanceID);
+        $this->InstanceID = $InstanceID;
     }
 
     public function Create(): void

--- a/ModuleStrictStubs.php
+++ b/ModuleStrictStubs.php
@@ -16,9 +16,9 @@ class IPSModulePublic extends IPSModule
 
 class IPSModuleStrict
 {
+    protected $InstanceID;
     private IPSModulePublic $module;
     private array $protectedMethods;
-    protected $InstanceID;
 
     public function __construct(int $InstanceID)
     {


### PR DESCRIPTION
Bei IPSModulStrict fehlte bisher die InstanceID 